### PR TITLE
increasing timeframe to 10 mins for the sso

### DIFF
--- a/includes/SSO_Helpers.php
+++ b/includes/SSO_Helpers.php
@@ -68,7 +68,7 @@ class SSO_Helpers {
 
 		// Validate timeframe
 		$time = array_shift( $parts );
-		if ( ! $time || ( $time + 60 ) < time() ) {
+		if ( ! $time || ( $time + 600 ) < time() ) {
 			return false;
 		}
 


### PR DESCRIPTION
Currently the SSO magic url is not working for migration module after they complete the migration. it is redirecting to login page instead of dashboard. Raising this PR to increase the time limit to 10mins as suggested by @chrisdavidmiles 