### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable-translations to push the auto-translate branch and catalogs to the caller repository.
       pull-requests: write # Required for reusable workflows that manage translation pull requests (`gh`, PR comments, or merges).
+    timeout-minutes: 120
     with:
       text_domain: 'wp-module-sso'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for reusable-translations to push the auto-translate branch and catalogs to the caller repository.
+      pull-requests: write # Required for reusable workflows that manage translation pull requests (`gh`, PR comments, or merges).
     with:
       text_domain: 'wp-module-sso'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Sets branch outputs from environment only; cloning runs in reusable workflow caller jobs below.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable module-plugin-test-playwright to checkout the private caller module and plugin repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable module-plugin-test-playwright to checkout the private caller module and plugin repositories.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # Sets branch outputs from environment only; cloning runs in reusable workflow caller jobs below.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable module-plugin-test-playwright to checkout the private caller module and plugin repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable module-plugin-test-playwright to checkout the private caller module and plugin repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Computes repository name only (no checkout or GitHub API).
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required so reusable-codecoverage can clone the caller repo (private) and push coverage to gh-pages.
+      pull-requests: write # Required so reusable-codecoverage can add or update coverage comments on PRs via mshick/add-pr-comment.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Computes repository name only (no checkout or GitHub API).
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required so reusable-codecoverage can clone the caller repo (private) and push coverage to gh-pages.
       pull-requests: write # Required so reusable-codecoverage can add or update coverage comments on PRs via mshick/add-pr-comment.
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required for actions/checkout to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required for actions/checkout to clone the repo.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -23,8 +23,8 @@ jobs:
     name: Prepare Release
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
-        contents: write
-        pull-requests: write
+      contents: write      # Required for reusable-module-prep-release to push the prepared release branch to the caller repository.
+      pull-requests: write # Required for reusable-module-prep-release to open the draft release pull request (`gh pr create`).
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable-module-prep-release to push the prepared release branch to the caller repository.
       pull-requests: write # Required for reusable-module-prep-release to open the draft release pull request (`gh pr create`).
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # The job sends repository_dispatch using secrets.WEBHOOK_TOKEN only; default GITHUB_TOKEN needs no scopes.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # The job sends repository_dispatch using secrets.WEBHOOK_TOKEN only; default GITHUB_TOKEN needs no scopes.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/auto-translate.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/lint.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (already existed) |
| Permissions commit | `3010564` |
| Timeouts commit | none |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/lint.yml` |
| Workflows where the top-level permissions block was replaced or completed to match the required default-deny pattern (comment + `permissions: {}`) relative to `main`: | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml` (previously `permissions: contents: read`) |
| Workflows where the top-level permissions block was replaced or completed to match the required default-deny pattern (comment + `permissions: {}`) relative to `main`: | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` (previously `permissions: contents: read`) |
| Workflows where the top-level permissions block was replaced or completed to match the required default-deny pattern (comment + `permissions: {}`) relative to `main`: | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/auto-translate.yml` (gained the required two-line comment immediately above `permissions: {}`) |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml` :: workflow: BEFORE top-level `permissions: contents: read` -> AFTER comment + `permissions: {}` -- move repository read implied-default to explicit job scoping; avoid granting read at workflow default when `get-repo-name` needs no token scopes -- [3] |
| 2 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` :: workflow: BEFORE top-level `permissions: contents: read` -> AFTER comment + `permissions: {}` -- same default-deny pattern; keep reads on jobs that invoke checkouts via reusable workflows -- [3] |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- job only computes branch name from event refs; no checkout or GitHub API use in this job -- [3] |
| 4 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` :: `bluehost`, `bluehost-dev`: BEFORE `permissions`/`uses` order and commentless keys -> AFTER `uses` then `contents: read` with rationale comment -- align caller reusable-workflow token shaping and document why read is needed for private checkouts -- [2] |
| 5 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml` :: `codecoverage`: BEFORE `permissions`/`uses` order and commentless keys -> AFTER `uses` then scoped `contents: write` / `pull-requests: write` with rationale comments -- document why the reusable codecoverage workflow needs write access (e.g., gh-pages + PR comments) -- [2] |
| 6 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/auto-translate.yml` :: `translate`: BEFORE `permissions`/`uses` order and commentless keys -> AFTER `uses` then scoped writes with rationale comments -- document push/PR automation needs for the reusable translations workflow -- [2] |
| 7 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/newfold-prep-release.yml` :: `prep-release`: BEFORE indented permissions without per-key comments -> AFTER normalized indentation + per-key comments -- document branch push and `gh pr create` style operations for the reusable prep-release workflow -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/satis-update.yml | webhook | `30` | Webhook-style job with three fast steps; bound runtime to avoid a stuck runner consuming minutes indefinitely (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/lint.yml | phpcs | `30` | Composer install + PHPCS over a PHP diff set typically finishes well under this cap (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml | get-repo-name | `5` | Single echo step; very small bound appropriate for a metadata-only job (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/codecoverage-main.yml | codecoverage | `60` | Multi-PHP matrix + coverage merge + Pages-style publishing in reusable workflow deserves a higher ceiling than lint (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml | setup | `5` | Branch extraction only (present only in working tree; not committed). |
| — | — | — | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` :: `bluehost`, `bluehost-dev` -> `60` -- Playwright-driven brand-plugin builds can be slow; 60 minutes is a reasonable upper bound without matching default 360 (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/newfold-prep-release.yml | prep-release | `30` | Release prep (version bumps, branch/PR automation) should complete quickly; cap prevents hung reusable workflow (present only in working tree; not committed). |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/auto-translate.yml | translate | `120` | Translation sync jobs may run longer due to external API + many file updates; more permissive cap than typical CI (present only in working tree; not committed). |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions` could not be fetched in this environment (timeout); assessment still used GitHub’s documented least-privilege model for `GITHUB_TOKEN` and the observable step/action inputs. |
| 2 | `newfold-labs/workflows` reusable workflow internals were not re-fetched line-by-line; job permissions are justified from caller contracts (`secrets: inherit`, `repo_token: ${{ secrets.GITHUB_TOKEN }}`, and typical checkout/PR/Pages behaviour) — confidence capped at [2] where reuse is involved. |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-sso/.github/workflows/brand-plugin-test-playwright.yml` orders `concurrency` after top-level `permissions: {}` and immediately before `jobs:`; if your governance text is interpreted strictly as “only comment + `permissions: {}` may appear immediately above `jobs:`”, consider moving `concurrency` above the permissions block for literal compliance — [2]. |
| 4 | `peter-evans/repository-dispatch@v4.0.1` uses `secrets.WEBHOOK_TOKEN` rather than `github.token`; explicit `permissions: {}` on `satis-update` is consistent with that configuration — [3]. |
| 5 | `timeout-minutes` changes exist in the working tree but are **not** in `3010564`; create the separate `chore(workflows): add timeout-minutes to jobs` commit locally when ready (no push performed in this audit). |


