### PR TITLE
Consume the SSO token on the legacy login path (PRESS0-4965)

### DIFF
--- a/includes/SSO_Helpers_Legacy.php
+++ b/includes/SSO_Helpers_Legacy.php
@@ -2,6 +2,9 @@
 
 namespace NewfoldLabs\WP\Module\SSO;
 
+/**
+ * Legacy SSO login handler.
+ */
 class SSO_Helpers_Legacy extends SSO_Helpers {
 
 	/**
@@ -12,7 +15,8 @@ class SSO_Helpers_Legacy extends SSO_Helpers {
 	/**
 	 * Handle SSO login.
 	 *
-	 * @param string $token
+	 * @param string $nonce SSO nonce from the request.
+	 * @param string $salt  SSO salt from the request.
 	 */
 	public static function handleLegacyLogin( $nonce, $salt ) {
 
@@ -56,6 +60,13 @@ class SSO_Helpers_Legacy extends SSO_Helpers {
 			self::triggerFailure();
 			exit;
 		}
+
+		// Consume the token so a single-use legacy SSO link cannot be replayed.
+		// Mirrors SSO_Helpers::handleLogin(), which deletes its user-meta token on
+		// success. The token can live in either store (see the dual read above), so
+		// clear both.
+		delete_transient( 'sso_token' );
+		delete_option( 'sso_token' );
 
 		// Do login
 		self::triggerSuccess( $user );

--- a/tests/wpunit/SSO_Helpers_LegacyWPUnitTest.php
+++ b/tests/wpunit/SSO_Helpers_LegacyWPUnitTest.php
@@ -16,6 +16,13 @@ class SSO_Helpers_LegacyWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCa
 	const REDIRECT_SIGNAL = 'sso-legacy-redirect';
 
 	/**
+	 * The wp_redirect interceptor, kept so it can be removed in tearDown.
+	 *
+	 * @var callable
+	 */
+	private $redirect_filter;
+
+	/**
 	 * Set up: turn the redirect+exit at the end of triggerSuccess/triggerFailure
 	 * into a catchable exception, and avoid sending real auth cookies in CLI.
 	 *
@@ -24,14 +31,13 @@ class SSO_Helpers_LegacyWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCa
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->redirect_filter = static function () {
+			// A fixed control-flow marker, not request output.
+			throw new \RuntimeException( self::REDIRECT_SIGNAL ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		};
+
 		add_filter( 'send_auth_cookies', '__return_false' );
-		add_filter(
-			'wp_redirect',
-			static function () {
-				// A fixed control-flow marker, not request output.
-				throw new \RuntimeException( self::REDIRECT_SIGNAL ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			}
-		);
+		add_filter( 'wp_redirect', $this->redirect_filter );
 
 		delete_transient( 'sso_token' );
 		delete_option( 'sso_token' );
@@ -39,11 +45,14 @@ class SSO_Helpers_LegacyWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCa
 	}
 
 	/**
-	 * Tear down: clear the token stores and throttle counter.
+	 * Tear down: remove the filters this test added and clear token stores.
 	 *
 	 * @return void
 	 */
 	public function tearDown(): void {
+		remove_filter( 'send_auth_cookies', '__return_false' );
+		remove_filter( 'wp_redirect', $this->redirect_filter );
+
 		delete_transient( 'sso_token' );
 		delete_option( 'sso_token' );
 		delete_transient( 'newfold_sso_failure_count' );
@@ -122,6 +131,46 @@ class SSO_Helpers_LegacyWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCa
 			0,
 			absint( get_transient( 'newfold_sso_failure_count' ) ),
 			'Replaying a consumed legacy link must be treated as a failed attempt.'
+		);
+	}
+
+	/**
+	 * A token stored in the option (transient empty) is also consumed on success,
+	 * exercising the dual-read / dual-delete path.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_login_consumes_token_from_option_store() {
+		$nonce = 'valid-nonce';
+		$salt  = 'valid-salt';
+		delete_transient( 'sso_token' );
+		update_option( 'sso_token', $this->make_token( $nonce, $salt ) );
+
+		$this->run_legacy_login( $nonce, $salt );
+
+		$this->assertFalse( get_option( 'sso_token' ), 'The option-store token must be deleted on success.' );
+		$this->assertFalse( get_transient( 'sso_token' ), 'No token transient should remain.' );
+	}
+
+	/**
+	 * A failed attempt (wrong nonce/salt) must NOT consume the stored token, so a
+	 * later attempt with the correct link still works.
+	 *
+	 * @return void
+	 */
+	public function test_failed_legacy_login_does_not_consume_token() {
+		$nonce = 'valid-nonce';
+		$salt  = 'valid-salt';
+		$token = $this->make_token( $nonce, $salt );
+		set_transient( 'sso_token', $token );
+
+		// Wrong salt => computed token will not match the stored one => failure.
+		$this->run_legacy_login( $nonce, 'wrong-salt' );
+
+		$this->assertSame(
+			$token,
+			get_transient( 'sso_token' ),
+			'A failed legacy login must leave the stored token intact.'
 		);
 	}
 }

--- a/tests/wpunit/SSO_Helpers_LegacyWPUnitTest.php
+++ b/tests/wpunit/SSO_Helpers_LegacyWPUnitTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\SSO;
+
+/**
+ * Tests for SSO_Helpers_Legacy.
+ *
+ * @covers \NewfoldLabs\WP\Module\SSO\SSO_Helpers_Legacy
+ */
+class SSO_Helpers_LegacyWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
+
+	/**
+	 * Marker thrown from the wp_redirect filter so the trigger* redirect+exit
+	 * becomes a catchable signal instead of ending the test run.
+	 */
+	const REDIRECT_SIGNAL = 'sso-legacy-redirect';
+
+	/**
+	 * Set up: turn the redirect+exit at the end of triggerSuccess/triggerFailure
+	 * into a catchable exception, and avoid sending real auth cookies in CLI.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'send_auth_cookies', '__return_false' );
+		add_filter(
+			'wp_redirect',
+			static function () {
+				// A fixed control-flow marker, not request output.
+				throw new \RuntimeException( self::REDIRECT_SIGNAL ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			}
+		);
+
+		delete_transient( 'sso_token' );
+		delete_option( 'sso_token' );
+		delete_transient( 'newfold_sso_failure_count' );
+	}
+
+	/**
+	 * Tear down: clear the token stores and throttle counter.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		delete_transient( 'sso_token' );
+		delete_option( 'sso_token' );
+		delete_transient( 'newfold_sso_failure_count' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build the token the legacy handler expects for a given nonce + salt.
+	 *
+	 * @param string $nonce Nonce.
+	 * @param string $salt  Salt.
+	 *
+	 * @return string
+	 */
+	private function make_token( $nonce, $salt ) {
+		return substr( base64_encode( hash( 'sha256', $nonce . $salt, false ) ), 0, 64 );
+	}
+
+	/**
+	 * Run the legacy handler, absorbing the redirect+exit signal so the test can
+	 * continue and assert on side effects.
+	 *
+	 * @param string $nonce Nonce.
+	 * @param string $salt  Salt.
+	 *
+	 * @return void
+	 */
+	private function run_legacy_login( $nonce, $salt ) {
+		try {
+			SSO_Helpers_Legacy::handleLegacyLogin( $nonce, $salt );
+			$this->fail( 'handleLegacyLogin should always end in a redirect (exit).' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertSame( self::REDIRECT_SIGNAL, $e->getMessage() );
+		}
+	}
+
+	/**
+	 * A successful legacy login consumes the token so the same link cannot be replayed.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_login_consumes_token_on_success() {
+		$nonce = 'valid-nonce'; // No -e<epoch> suffix, so it does not expire on its own.
+		$salt  = 'valid-salt';
+		set_transient( 'sso_token', $this->make_token( $nonce, $salt ) );
+
+		$this->run_legacy_login( $nonce, $salt );
+
+		$this->assertFalse(
+			get_transient( 'sso_token' ),
+			'A successful legacy login must delete the sso_token transient.'
+		);
+		$this->assertFalse(
+			get_option( 'sso_token' ),
+			'A successful legacy login must not leave the sso_token option behind.'
+		);
+	}
+
+	/**
+	 * After a successful legacy login, replaying the same link fails (the token is gone).
+	 *
+	 * @return void
+	 */
+	public function test_legacy_login_cannot_be_replayed() {
+		$nonce = 'valid-nonce';
+		$salt  = 'valid-salt';
+		set_transient( 'sso_token', $this->make_token( $nonce, $salt ) );
+
+		// First use succeeds and consumes the token.
+		$this->run_legacy_login( $nonce, $salt );
+		$this->assertSame( 0, absint( get_transient( 'newfold_sso_failure_count' ) ) );
+
+		// Replay of the same link is now rejected as a failure.
+		$this->run_legacy_login( $nonce, $salt );
+		$this->assertGreaterThan(
+			0,
+			absint( get_transient( 'newfold_sso_failure_count' ) ),
+			'Replaying a consumed legacy link must be treated as a failed attempt.'
+		);
+	}
+}


### PR DESCRIPTION
https://jira.newfold.com/browse/PRESS0-4965

## Proposed changes

`SSO_Helpers_Legacy::handleLegacyLogin()` validated the `sso_token` transient but **never deleted it on success**, so a legacy SSO login link could be replayed. The newer path (`SSO_Helpers::handleLogin()`) already deletes its user-meta token on success, and `triggerSuccess()` clears only that user-meta token — never the legacy transient. So the "single-use" label did not hold on the legacy path.

Two things make the window worse than it looks:
- The token is read from `get_transient('sso_token')` (set by `SSO_CLI`), which is not consumed, so the link works for the transient's whole lifetime.
- The expiry check only fires when the nonce carries a `-e<epoch>` suffix (`$has_epoch`). A nonce without that suffix is never treated as expired.

**Fix:** after a successful legacy login, delete the `sso_token` transient (and option — the handler reads from both stores) before `triggerSuccess()`, mirroring what the non-legacy path already does. A consumed link is now rejected on replay.

While in the file I also fixed its pre-existing docblock errors (the `handleLegacyLogin` docblock said `@param $token` but the params are `$nonce`/`$salt`, and the class had no doc comment) so the touched file passes `phpcs` cleanly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Screenshots

n/a — server-side auth path, no UI.

## Testing

`phpcs` clean on the changed files. Full `wpunit` suite green (34 tests). Added `SSO_Helpers_LegacyWPUnitTest` (the legacy handler had no coverage before):
- `test_legacy_login_consumes_token_on_success` — after a successful login, the `sso_token` transient and option are gone.
- `test_legacy_login_cannot_be_replayed` — replaying the same link after consumption is rejected as a failed attempt.

The tests intercept the `wp_redirect` filter to turn `triggerSuccess`/`triggerFailure`'s redirect+`exit` into a catchable signal, and disable `send_auth_cookies` so no real cookies are sent under CLI.

**Mutation-checked.** Removing the two delete calls makes both new tests fail (token survives, replay succeeds) — confirming they catch the regression.

## Further comments

Scope is the legacy path only; the non-legacy path already consumes its token. No behavior change for a legitimate one-time login — only replays of an already-used link are now rejected.
